### PR TITLE
Remove .edgesIgnoringSafeArea line from sample app code

### DIFF
--- a/Example/SamplePlaybook/SceneDelegate.swift
+++ b/Example/SamplePlaybook/SceneDelegate.swift
@@ -26,7 +26,6 @@ struct PlaybookView: View {
                     Text("Catalog")
                 }
         }
-            .edgesIgnoringSafeArea(.top)
     }
 }
 


### PR DESCRIPTION
## Checklist

- [x] All tests are passed.  
- [ ] Added tests or Playbook scenario.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description
Remove `.edgesIgnoringSafeArea` line from sample app code


## Related Issue
Closes #20

## Motivation and Context


## Screenshot
Fixed screen shot:
<img width="1274" alt="Screen Shot 2020-04-06 at 21 26 20" src="https://user-images.githubusercontent.com/3097559/78558766-257db900-784e-11ea-975e-060adb0387ab.png">
