### PR TITLE
fix import so sample app builds

### DIFF
--- a/Example/SampleApp/SceneDelegate.swift
+++ b/Example/SampleApp/SceneDelegate.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import Components
+import SampleComponent
 
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?


### PR DESCRIPTION
## Checklist

- [ x ] All tests are passed.  
- [ n/a ] Added tests or Playbook scenario.  
- [ n/a ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [ x ] Searched existing pull requests for ensure not duplicated.  

## Description
SampleApp doesn't build. This import fixes it.

## Related Issue


## Motivation and Context


## Screenshots
