### PR TITLE
Support for AccessibilitySnapshot

### DIFF
--- a/Sources/Playbook/SnapshotSupport/Internal/SnapshotWindow.swift
+++ b/Sources/Playbook/SnapshotSupport/Internal/SnapshotWindow.swift
@@ -8,10 +8,6 @@ internal final class SnapshotWindow: UIWindow {
     var contentView: UIView? {
         scenarioViewController.contentViewController?.view
     }
-    
-    var scenarioView: UIView {
-        scenarioViewController.view
-    }
 
     override var traitCollection: UITraitCollection {
         UITraitCollection(traitsFrom: [super.traitCollection, device.traitCollection])

--- a/Sources/Playbook/SnapshotSupport/Internal/SnapshotWindow.swift
+++ b/Sources/Playbook/SnapshotSupport/Internal/SnapshotWindow.swift
@@ -8,6 +8,10 @@ internal final class SnapshotWindow: UIWindow {
     var contentView: UIView? {
         scenarioViewController.contentViewController?.view
     }
+    
+    var scenarioView: UIView {
+        scenarioViewController.view
+    }
 
     override var traitCollection: UITraitCollection {
         UITraitCollection(traitsFrom: [super.traitCollection, device.traitCollection])

--- a/Sources/Playbook/SnapshotSupport/SnapshotSupport.swift
+++ b/Sources/Playbook/SnapshotSupport/SnapshotSupport.swift
@@ -71,7 +71,7 @@ public enum SnapshotSupport {
             handler(resource.renderer.image(actions: resource.actions))
         }
     }
-    
+
     /// Generates an `UIView` that snapshots the given scenario.
     ///
     /// - Parameters:
@@ -105,12 +105,12 @@ public enum SnapshotSupport {
                 if contentView.bounds.size.height <= 0 {
                     fatalError("The view was laid out with zero height in scenario - \(scenario.name)", file: scenario.file, line: scenario.line)
                 }
-            
-                handler(window.scenarioView)
+
+                handler(contentView)
             }
         }
     }
-    
+
     /// Generates an image file data for the given `UIView`
     ///
     /// - Parameters:
@@ -143,7 +143,7 @@ private extension SnapshotSupport {
         var renderer: UIGraphicsImageRenderer
         var actions: UIGraphicsDrawingActions
     }
-    
+
     static func makeResource(
         for scenario: Scenario,
         on device: SnapshotDevice,
@@ -151,9 +151,9 @@ private extension SnapshotSupport {
         keyWindow: UIWindow?,
         completion: @escaping (Resource) -> Void
     ) {
-        view(for: scenario, on: device, keyWindow: keyWindow) { scenarioView in
+        view(for: scenario, on: device, keyWindow: keyWindow) { contentView in
             makeResource(
-                for: scenarioView,
+                for: contentView,
                 on: device,
                 scale: scale,
                 keyWindow: keyWindow,
@@ -161,7 +161,7 @@ private extension SnapshotSupport {
             )
         }
     }
-    
+
     static func makeResource(
         for view: UIView,
         on device: SnapshotDevice,
@@ -171,14 +171,14 @@ private extension SnapshotSupport {
     ) {
         let format = UIGraphicsImageRendererFormat(for: device.traitCollection)
         format.scale = scale
-        
+
         if #available(iOS 12.0, *) {
             format.preferredRange = .standard
         }
         else {
             format.prefersExtendedRange = false
         }
-        
+
         let isEmbedInKeyWindow = keyWindow != nil
         let renderer = UIGraphicsImageRenderer(bounds: view.bounds, format: format)
         let actions: UIGraphicsDrawingActions = { context in
@@ -192,11 +192,11 @@ private extension SnapshotSupport {
                 }
             }
         }
-        
+
         let resource = Resource(renderer: renderer, actions: actions)
         completion(resource)
     }
-    
+
     static func withoutAnimation<T>(_ action: () throws -> T) rethrows -> T {
         let disableActions = CATransaction.disableActions()
         CATransaction.setDisableActions(true)

--- a/Sources/Playbook/SnapshotSupport/SnapshotSupport.swift
+++ b/Sources/Playbook/SnapshotSupport/SnapshotSupport.swift
@@ -72,10 +72,20 @@ public enum SnapshotSupport {
         }
     }
     
+    /// Generates an `UIView` that snapshots the given scenario.
+    ///
+    /// - Parameters:
+    ///   - scenario: A scenario to be snapshot.
+    ///   - device: A snapshot environment simulating device.
+    ///   - keyWindow: The key window of the application.
+    ///   - handler: A closure that to handle generated `UIView`.
+    ///
+    /// - Note: Passing the key window adds the scenario content to the view
+    ///         hierarchy and actually renders it, so producing a more accurate
+    ///         snapshot image.
     public static func view(
         for scenario: Scenario,
         on device: SnapshotDevice,
-        scale: CGFloat = UIScreen.main.scale,
         keyWindow: UIWindow? = nil,
         handler: @escaping (UIView) -> Void
     ) {
@@ -101,6 +111,19 @@ public enum SnapshotSupport {
         }
     }
     
+    /// Generates an image file data for the given `UIView`
+    ///
+    /// - Parameters:
+    ///   - view: A `UIView` of a snapshot.
+    ///   - device: A snapshot environment simulating device.
+    ///   - format: An image file format of exported data.
+    ///   - scale: A rendering scale of the snapshot image.
+    ///   - keyWindow: The key window of the application.
+    ///   - handler: A closure that to handle generated data.
+    ///
+    /// - Note: Passing the key window adds the scenario content to the view
+    ///         hierarchy and actually renders it, so producing a more accurate
+    ///         snapshot image.
     public static func data(
         for view: UIView,
         on device: SnapshotDevice,
@@ -128,7 +151,7 @@ private extension SnapshotSupport {
         keyWindow: UIWindow?,
         completion: @escaping (Resource) -> Void
     ) {
-        view(for: scenario, on: device, scale: scale, keyWindow: keyWindow) { scenarioView in
+        view(for: scenario, on: device, keyWindow: keyWindow) { scenarioView in
             makeResource(
                 for: scenarioView,
                 on: device,

--- a/Sources/PlaybookSnapshot/Snapshot.swift
+++ b/Sources/PlaybookSnapshot/Snapshot.swift
@@ -97,33 +97,16 @@ public struct Snapshot: TestTool {
                         attemptToWrite(data: data, scenario: scenario)
                         group.leave()
                     }
-                    
-                    if let viewPreprocessor = self.viewPreprocessor {
-                        SnapshotSupport.view(
-                            for: scenario,
-                            on: device,
-                            keyWindow: keyWindow) { contentView in
-                            let processedView = viewPreprocessor(contentView)
-                            
-                            SnapshotSupport.data(
-                                for: processedView,
-                                on: device,
-                                format: format,
-                                scale: scale,
-                                keyWindow: keyWindow,
-                                handler: handler
-                            )
-                        }
-                    } else {
-                        SnapshotSupport.data(
-                            for: scenario,
-                            on: device,
-                            format: format,
-                            scale: scale,
-                            keyWindow: keyWindow,
-                            handler: handler
-                        )
-                    }
+
+                    SnapshotSupport.data(
+                        for: scenario,
+                        on: device,
+                        format: format,
+                        scale: scale,
+                        keyWindow: keyWindow,
+                        viewPreprocessor: viewPreprocessor,
+                        handler: handler
+                    )
                 }
             }
         }

--- a/Sources/PlaybookSnapshot/Snapshot.swift
+++ b/Sources/PlaybookSnapshot/Snapshot.swift
@@ -92,11 +92,6 @@ public struct Snapshot: TestTool {
 
                 for scenario in store.scenarios {
                     group.enter()
-                    
-                    let handler: (Data) -> Void  = { data in
-                        attemptToWrite(data: data, scenario: scenario)
-                        group.leave()
-                    }
 
                     SnapshotSupport.data(
                         for: scenario,
@@ -105,7 +100,10 @@ public struct Snapshot: TestTool {
                         scale: scale,
                         keyWindow: keyWindow,
                         viewPreprocessor: viewPreprocessor,
-                        handler: handler
+                        handler: { data in
+                            attemptToWrite(data: data, scenario: scenario)
+                            group.leave()
+                        }
                     )
                 }
             }

--- a/Sources/PlaybookSnapshot/Snapshot.swift
+++ b/Sources/PlaybookSnapshot/Snapshot.swift
@@ -102,8 +102,8 @@ public struct Snapshot: TestTool {
                         SnapshotSupport.view(
                             for: scenario,
                             on: device,
-                            keyWindow: keyWindow) { scenarioView in
-                            let processedView = viewPreprocessor(scenarioView)
+                            keyWindow: keyWindow) { contentView in
+                            let processedView = viewPreprocessor(contentView)
                             
                             SnapshotSupport.data(
                                 for: processedView,

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -28,4 +28,31 @@ final class SnapshotTests: XCTestCase {
             )
         )
     }
+    
+    func testTakeSnapshotWithPreprocessor() throws {
+        guard let directory = ProcessInfo.processInfo.environment["SNAPSHOT_DIR"] else {
+            fatalError("Set directory to the build environment variables with key `SNAPSHOT_DIR`.")
+        }
+
+        Playbook.default.add(AllScenarios.self)
+        
+        let preprocessor: ((UIView) -> UIView) = { view in
+            view.backgroundColor = .lightGray
+            return view
+        }
+
+        try Playbook.default.run(
+            Snapshot(
+                directory: URL(fileURLWithPath: directory),
+                clean: true,
+                format: .png,
+                scale: 1,
+                keyWindow: UIApplication.shared.windows.first { $0.isKeyWindow },
+                devices: [
+                    .iPhone11Pro(.portrait),
+                ],
+                viewPreprocessor:preprocessor
+            )
+        )
+    }
 }

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -28,22 +28,17 @@ final class SnapshotTests: XCTestCase {
             )
         )
     }
-    
+
     func testTakeSnapshotWithPreprocessor() throws {
         guard let directory = ProcessInfo.processInfo.environment["SNAPSHOT_DIR"] else {
             fatalError("Set directory to the build environment variables with key `SNAPSHOT_DIR`.")
         }
 
         Playbook.default.add(AllScenarios.self)
-        
-        let preprocessor: ((UIView) -> UIView) = { view in
-            view.backgroundColor = .lightGray
-            return view
-        }
 
         try Playbook.default.run(
             Snapshot(
-                directory: URL(fileURLWithPath: directory),
+                directory: URL(fileURLWithPath: directory).appendingPathComponent("GrayBackground"),
                 clean: true,
                 format: .png,
                 scale: 1,
@@ -51,7 +46,10 @@ final class SnapshotTests: XCTestCase {
                 devices: [
                     .iPhone11Pro(.portrait),
                 ],
-                viewPreprocessor:preprocessor
+                viewPreprocessor: { view in
+                    view.backgroundColor = .lightGray
+                    return view
+                }
             )
         )
     }


### PR DESCRIPTION
## Checklist

- [x] All tests are passed.  
- [x] Added tests or Playbook scenario.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description
In order to create an extension to Playbook for accessibility testing, the UIView of the scenario snapshot is needed. The function `makeResource` is split into two parts: creating the UIView using SnapshotWindow and generating the image data of the UIView.

## Motivation and Context
This is to create PlaybookAccessibility (WIP) and it uses [AccessibilitySnapshot](https://github.com/cashapp/AccessibilitySnapshot). To do this: 
1. AccessibilitySnapshot takes the UIView of a scenario using `SnapshotSupport.view(...)`
2. An AccessibilitySnapshotView is generated
3. AccessibilitySnapshotView is passed to `snapshotSupport.data(for: view, ...)` to generate image data for saving