### PR TITLE
Remove VALID_ARCHS

### DIFF
--- a/XCConfigs/project.xcconfig
+++ b/XCConfigs/project.xcconfig
@@ -1,8 +1,6 @@
 SDKROOT =
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator
 TARGETED_DEVICE_FAMILY = 1,2
-VALID_ARCHS[sdk=iphoneos*] = arm64 armv7 armv7s
-VALID_ARCHS[sdk=iphonesimulator*] = i386 x86_64
 
 BUILD_LIBRARY_FOR_DISTRIBUTION = YES
 CODE_SIGNING_REQUIRED = NO

--- a/XCConfigs/project.xcconfig
+++ b/XCConfigs/project.xcconfig
@@ -1,6 +1,8 @@
 SDKROOT =
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator
 TARGETED_DEVICE_FAMILY = 1,2
+VALID_ARCHS[sdk=iphoneos*] = arm64 armv7 armv7s
+VALID_ARCHS[sdk=iphonesimulator*] = arm64 i386 x86_64
 
 BUILD_LIBRARY_FOR_DISTRIBUTION = YES
 CODE_SIGNING_REQUIRED = NO


### PR DESCRIPTION
## Checklist

- [x] All tests are passed.  
- [ ] Added tests or Playbook scenario.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description

Remove VALID_ARCHS since it's not used in Xcode 12 by default.
This will support Apple Silicon builds.