### PR TITLE
feat: Add support for iPhone12 series for snapshot

### DIFF
--- a/Sources/Playbook/SnapshotSupport/SnapshotDevice.swift
+++ b/Sources/Playbook/SnapshotSupport/SnapshotDevice.swift
@@ -78,7 +78,10 @@ public struct SnapshotDevice {
             traitCollection: UITraitCollection(traitsFrom: [self.traitCollection, traitCollection])
         )
     }
+}
 
+/// iPhone SE Series
+public extension SnapshotDevice {
     /// `iPhone SE` simulated device.
     ///
     /// - Parameters:
@@ -87,7 +90,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPhone SE`.
     @available(iOS 12.0, *)
-    public static func iPhoneSE(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPhoneSE(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPhoneSE(orientation).style(style)
     }
 
@@ -97,7 +100,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPhone SE`.
-    public static func iPhoneSE(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPhoneSE(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPhone SE \(orientation.string)",
             size: orientation.use(
@@ -120,7 +123,10 @@ public struct SnapshotDevice {
             )
         )
     }
+}
 
+/// iPhone 8 Series
+public extension SnapshotDevice {
     /// `iPhone 8` simulated device.
     ///
     /// - Parameters:
@@ -129,7 +135,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPhone 8`.
     @available(iOS 12.0, *)
-    public static func iPhone8(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPhone8(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPhone8(orientation).style(style)
     }
 
@@ -139,7 +145,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPhone 8`.
-    public static func iPhone8(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPhone8(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPhone 8 \(orientation.string)",
             size: orientation.use(
@@ -171,7 +177,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPhone 8 Plus`.
     @available(iOS 12.0, *)
-    public static func iPhone8Plus(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPhone8Plus(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPhone8Plus(orientation).style(style)
     }
 
@@ -181,7 +187,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPhone 8 Plus`.
-    public static func iPhone8Plus(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPhone8Plus(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPhone 8 Plus \(orientation.string)",
             size: orientation.use(
@@ -204,7 +210,10 @@ public struct SnapshotDevice {
             )
         )
     }
+}
 
+/// iPhone X Series
+public extension SnapshotDevice {
     /// `iPhone X` simulated device.
     ///
     /// - Parameters:
@@ -213,7 +222,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPhone X`.
     @available(iOS 12.0, *)
-    public static func iPhoneX(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPhoneX(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPhoneX(orientation).style(style)
     }
 
@@ -223,7 +232,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPhone X`.
-    public static func iPhoneX(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPhoneX(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPhone X \(orientation.string)",
             size: orientation.use(
@@ -255,7 +264,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPhone XS`.
     @available(iOS 12.0, *)
-    public static func iPhoneXS(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPhoneXS(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPhoneXS(orientation).style(style)
     }
 
@@ -265,7 +274,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPhone XS`.
-    public static func iPhoneXS(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPhoneXS(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPhone XS \(orientation.string)",
             size: orientation.use(
@@ -297,7 +306,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPhone XR`.
     @available(iOS 12.0, *)
-    public static func iPhoneXR(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPhoneXR(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPhoneXR(orientation).style(style)
     }
 
@@ -307,7 +316,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPhone XR`.
-    public static func iPhoneXR(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPhoneXR(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPhone XR \(orientation.string)",
             size: orientation.use(
@@ -339,7 +348,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPhone XS Max`.
     @available(iOS 12.0, *)
-    public static func iPhoneXSMax(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPhoneXSMax(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPhoneXSMax(orientation).style(style)
     }
 
@@ -349,7 +358,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPhone XS Max`.
-    public static func iPhoneXSMax(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPhoneXSMax(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPhone XS Max \(orientation.string)",
             size: orientation.use(
@@ -372,7 +381,10 @@ public struct SnapshotDevice {
             )
         )
     }
+}
 
+/// iPhone 11 Series
+public extension SnapshotDevice {
     /// `iPhone 11` simulated device.
     ///
     /// - Parameters:
@@ -381,7 +393,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPhone 11`.
     @available(iOS 12.0, *)
-    public static func iPhone11(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPhone11(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPhone11(orientation).style(style)
     }
 
@@ -391,7 +403,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPhone 11`.
-    public static func iPhone11(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPhone11(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPhone 11 \(orientation.string)",
             size: orientation.use(
@@ -423,7 +435,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPhone 11 Pro`.
     @available(iOS 12.0, *)
-    public static func iPhone11Pro(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPhone11Pro(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPhone11Pro(orientation).style(style)
     }
 
@@ -433,7 +445,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPhone 11 Pro`.
-    public static func iPhone11Pro(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPhone11Pro(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPhone 11 Pro \(orientation.string)",
             size: orientation.use(
@@ -451,7 +463,7 @@ public struct SnapshotDevice {
                 horizontalSizeClass: .compact,
                 verticalSizeClass: orientation.use(portrait: .regular, landscape: .compact),
                 layoutDirection: .leftToRight,
-                forceTouchCapability: .available,
+                forceTouchCapability: .unavailable,
                 preferredContentSizeCategory: .medium
             )
         )
@@ -465,7 +477,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPhone 11 Pro Max`.
     @available(iOS 12.0, *)
-    public static func iPhone11ProMax(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPhone11ProMax(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPhone11ProMax(orientation).style(style)
     }
 
@@ -475,7 +487,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPhone 11 Pro Max`.
-    public static func iPhone11ProMax(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPhone11ProMax(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPhone 11 Pro Max \(orientation.string)",
             size: orientation.use(
@@ -493,12 +505,166 @@ public struct SnapshotDevice {
                 horizontalSizeClass: orientation.use(portrait: .compact, landscape: .regular),
                 verticalSizeClass: orientation.use(portrait: .regular, landscape: .compact),
                 layoutDirection: .leftToRight,
-                forceTouchCapability: .available,
+                forceTouchCapability: .unavailable,
+                preferredContentSizeCategory: .medium
+            )
+        )
+    }
+}
+
+/// iPhone 12 Series
+public extension SnapshotDevice {
+    /// `iPhone 12 mini` simulated device.
+    ///
+    /// - Parameters:
+    ///    - orientation: A simulated orientation.
+    ///    - style: A theme of UI appearance.
+    ///
+    /// - Returns: A device simulated the `iPhone 12 mini`.
+    @available(iOS 12.0, *)
+    static func iPhone12Mini(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+        iPhone12(orientation).style(style)
+    }
+
+    /// `iPhone 12 mini` simulated device.
+    ///
+    /// - Parameters:
+    ///    - orientation: A simulated orientation.
+    ///
+    /// - Returns: A device simulated the `iPhone 12 mini`.
+    static func iPhone12Mini(_ orientation: Orientation) -> SnapshotDevice {
+        SnapshotDevice(
+            name: "iPhone 12 mini \(orientation.string)",
+            size: orientation.use(
+                portrait: CGSize(width: 360, height: 780),
+                landscape: CGSize(width: 780, height: 360)
+            ),
+            safeAreaInsets: orientation.use(
+                portrait: UIEdgeInsets(top: 50, left: 0, bottom: 34, right: 0),
+                landscape: UIEdgeInsets(top: 0, left: 50, bottom: 21, right: 50)
+            ),
+            traitCollection: UITraitCollection(
+                userInterfaceIdiom: .phone,
+                displayScale: 3,
+                displayGamut: .P3,
+                horizontalSizeClass: .compact,
+                verticalSizeClass: orientation.use(portrait: .regular, landscape: .compact),
+                layoutDirection: .leftToRight,
+                forceTouchCapability: .unavailable,
                 preferredContentSizeCategory: .medium
             )
         )
     }
 
+    /// `iPhone 12` simulated device.
+    ///
+    /// - Parameters:
+    ///    - orientation: A simulated orientation.
+    ///    - style: A theme of UI appearance.
+    ///
+    /// - Returns: A device simulated the `iPhone 12`.
+    @available(iOS 12.0, *)
+    static func iPhone12(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+        iPhone12Pro(orientation, style: style)
+    }
+
+    /// `iPhone 12` simulated device.
+    ///
+    /// - Parameters:
+    ///    - orientation: A simulated orientation.
+    ///
+    /// - Returns: A device simulated the `iPhone 12`.
+    static func iPhone12(_ orientation: Orientation) -> SnapshotDevice {
+        iPhone12Pro(orientation)
+    }
+
+    /// `iPhone 12 Pro` simulated device.
+    ///
+    /// - Parameters:
+    ///    - orientation: A simulated orientation.
+    ///    - style: A theme of UI appearance.
+    ///
+    /// - Returns: A device simulated the `iPhone 12 Pro`.
+    @available(iOS 12.0, *)
+    static func iPhone12Pro(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+        iPhone12Pro(orientation).style(style)
+    }
+
+    /// `iPhone 12 Pro` simulated device.
+    ///
+    /// - Parameters:
+    ///    - orientation: A simulated orientation.
+    ///
+    /// - Returns: A device simulated the `iPhone 12 Pro`.
+    static func iPhone12Pro(_ orientation: Orientation) -> SnapshotDevice {
+        SnapshotDevice(
+            name: "iPhone 12 Pro \(orientation.string)",
+            size: orientation.use(
+                portrait: CGSize(width: 390, height: 844),
+                landscape: CGSize(width: 844, height: 390)
+            ),
+            safeAreaInsets: orientation.use(
+                portrait: UIEdgeInsets(top: 47, left: 0, bottom: 34, right: 0),
+                landscape: UIEdgeInsets(top: 0, left: 47, bottom: 21, right: 47)
+            ),
+            traitCollection: UITraitCollection(
+                userInterfaceIdiom: .phone,
+                displayScale: 3,
+                displayGamut: .P3,
+                horizontalSizeClass: .compact,
+                verticalSizeClass: orientation.use(portrait: .regular, landscape: .compact),
+                layoutDirection: .leftToRight,
+                forceTouchCapability: .unavailable,
+                preferredContentSizeCategory: .medium
+            )
+        )
+    }
+
+    /// `iPhone 12 Pro Max` simulated device.
+    ///
+    /// - Parameters:
+    ///    - orientation: A simulated orientation.
+    ///    - style: A theme of UI appearance.
+    ///
+    /// - Returns: A device simulated the `iPhone 12 Pro Max`.
+    @available(iOS 12.0, *)
+    static func iPhone12ProMax(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+        iPhone12ProMax(orientation).style(style)
+    }
+
+    /// `iPhone 12 Pro Max` simulated device.
+    ///
+    /// - Parameters:
+    ///    - orientation: A simulated orientation.
+    ///
+    /// - Returns: A device simulated the `iPhone 12 Pro Max`.
+    static func iPhone12ProMax(_ orientation: Orientation) -> SnapshotDevice {
+        SnapshotDevice(
+            name: "iPhone 12 Pro Max \(orientation.string)",
+            size: orientation.use(
+                portrait: CGSize(width: 428, height: 926),
+                landscape: CGSize(width: 926, height: 428)
+            ),
+            safeAreaInsets: orientation.use(
+                portrait: UIEdgeInsets(top: 47, left: 0, bottom: 34, right: 0),
+                landscape: UIEdgeInsets(top: 0, left: 47, bottom: 21, right: 47)
+            ),
+            traitCollection: UITraitCollection(
+                userInterfaceIdiom: .phone,
+                displayScale: 3,
+                displayGamut: .P3,
+                horizontalSizeClass: orientation.use(portrait: .compact, landscape: .regular),
+                verticalSizeClass: orientation.use(portrait: .regular, landscape: .compact),
+                layoutDirection: .leftToRight,
+                forceTouchCapability: .unavailable,
+                preferredContentSizeCategory: .medium
+            )
+        )
+    }
+}
+
+/// iPad Mini 5th
+public extension SnapshotDevice {
     /// `iPad Mini 5th generation` simulated device.
     ///
     /// - Parameters:
@@ -507,7 +673,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPad Mini 5th generation`.
     @available(iOS 12.0, *)
-    public static func iPadMini5th(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPadMini5th(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPadMini5th(orientation).style(style)
     }
 
@@ -517,7 +683,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPad Mini 5th generation`.
-    public static func iPadMini5th(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPadMini5th(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPad mini 5th \(orientation.string)",
             size: orientation.use(
@@ -537,7 +703,10 @@ public struct SnapshotDevice {
             )
         )
     }
+}
 
+/// iPad Pro
+public extension SnapshotDevice {
     /// `iPad Pro 10.5 inch` simulated device.
     ///
     /// - Parameters:
@@ -546,7 +715,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPad Pro 10.5 inch`.
     @available(iOS 12.0, *)
-    public static func iPadPro10_5(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPadPro10_5(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPadPro10_5(orientation).style(style)
     }
 
@@ -556,7 +725,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPad Pro 10.5 inch`.
-    public static func iPadPro10_5(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPadPro10_5(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPad Pro 10_5 \(orientation.string)",
             size: orientation.use(
@@ -585,7 +754,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPad Pro 11`.
     @available(iOS 12.0, *)
-    public static func iPadPro11(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPadPro11(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPadPro11(orientation).style(style)
     }
 
@@ -595,7 +764,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPad Pro 11`.
-    public static func iPadPro11(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPadPro11(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPad Pro 11 \(orientation.string)",
             size: orientation.use(
@@ -624,7 +793,7 @@ public struct SnapshotDevice {
     ///
     /// - Returns: A device simulated the `iPad Pro 12.9 inch`.
     @available(iOS 12.0, *)
-    public static func iPadPro12_9(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
+    static func iPadPro12_9(_ orientation: Orientation, style: UIUserInterfaceStyle) -> SnapshotDevice {
         iPadPro12_9(orientation).style(style)
     }
 
@@ -634,7 +803,7 @@ public struct SnapshotDevice {
     ///    - orientation: A simulated orientation.
     ///
     /// - Returns: A device simulated the `iPad Pro 12.9 inch`.
-    public static func iPadPro12_9(_ orientation: Orientation) -> SnapshotDevice {
+    static func iPadPro12_9(_ orientation: Orientation) -> SnapshotDevice {
         SnapshotDevice(
             name: "iPad Pro 12_9 \(orientation.string)",
             size: orientation.use(


### PR DESCRIPTION
## Checklist

- [x] All tests are passed.  
- [ ] Added tests or Playbook scenario.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description

- Add support for iPhone12, iPhone12 mini, iPhone12 Pro, and iPhone12 Pro Max, for snapshot.
