### PR TITLE
fix: Wrong device definition

### DIFF
--- a/Sources/Playbook/SnapshotSupport/SnapshotDevice.swift
+++ b/Sources/Playbook/SnapshotSupport/SnapshotDevice.swift
@@ -43,6 +43,15 @@ public struct SnapshotDevice {
         self.traitCollection = traitCollection
     }
 
+    /// Adds a user interface style as a trait collection.
+    /// - Parameter style: A user interface style to be used.
+    /// - Returns: The device that added the given user interface style
+    ///            as a trait collection to `self`.
+    @available(iOS 12.0, *)
+    public func style(_ style: UIUserInterfaceStyle) -> SnapshotDevice {
+        addingTraitCollection(UITraitCollection(userInterfaceStyle: style))
+    }
+
     /// Adds an arbitrary trait collection to change the appearance.
     ///
     /// - Parameters
@@ -884,13 +893,6 @@ private extension UITraitCollection {
             UITraitCollection(forceTouchCapability: forceTouchCapability),
             UITraitCollection(preferredContentSizeCategory: preferredContentSizeCategory),
         ])
-    }
-}
-
-private extension SnapshotDevice {
-    @available(iOS 12.0, *)
-    func style(_ style: UIUserInterfaceStyle) -> SnapshotDevice {
-        addingTraitCollection(UITraitCollection(userInterfaceStyle: style))
     }
 }
 


### PR DESCRIPTION
## Checklist

- [x] All tests are passed.  
- [ ] Added tests or Playbook scenario.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description

- Fix wrongly defined device info.
- The utility contractor has been deprecated `SnapshotDevice.iPhoneXX(_:,style:)`