### PR TITLE
fix for iOS 16 - force safeAreaInsets update

### DIFF
--- a/Sources/Playbook/SnapshotSupport/Internal/SnapshotWindow.swift
+++ b/Sources/Playbook/SnapshotSupport/Internal/SnapshotWindow.swift
@@ -57,6 +57,14 @@ internal final class SnapshotWindow: UIWindow {
         isHidden = false
 
         if window != nil {
+            // In iOS 16 and 17, setting `isHidden` nor does not update
+            // the safeAreaInsets on the rootViewController's view. Updating
+            // `additionalSafeAreaInsets` will so force an update
+            if scenarioViewController.view.safeAreaInsets == .zero {
+                scenarioViewController.additionalSafeAreaInsets = .init(top: 1, left: 0, bottom: 0, right: 0)
+                scenarioViewController.additionalSafeAreaInsets = .zero
+            }
+
             // Prioritise use snapshot device's `safeAreaInsets`
             // by `additionalSafeAreaInsets` if having a parent window.
             let originalSafeAreaInsets = scenarioViewController.view.safeAreaInsets


### PR DESCRIPTION
## Checklist

- [x] All tests are passed.  
- [ ] Added tests or Playbook scenario.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description
- In iOS 15, setting `isHidden` to false on a `UIWindow` triggers an update to the `safeAreaInsets` on the view of the window's `rootViewController`. In iOS 16 (and the 17 beta), this update was not happening. So calculating `additionalSafeAreaInsets` was happening with `safeAreaInsets == .zero` instead of the correct value.

## Related Issue
N/A

## Motivation and Context
There were issues with layout of AccessibilitySnapshot. This led to a detailed investigation of the root cause and this pull request.

## Screenshots
Screenshots of debugging the calculation of `additionalSafeAreaInsets` in `SnapshotWindow.swift`  

__iOS 15__
![iOS15](https://github.com/playbook-ui/playbook-ios/assets/132260274/1dd00d9e-b3b5-4ccd-b79b-6e08767d8e7b)  

--

__iOS 16__
![ios16](https://github.com/playbook-ui/playbook-ios/assets/132260274/97b0dd8d-37bf-4808-983b-d449b93af842)

