### PR TITLE
Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ To run project, install dependencies and open workspace as following commands.
 ```bash
 $ git clone https://github.com/playbook-ui/playbook-ios.git
 $ cd playbook-ios
-$ open Exapmle/PlaybookExample.xcworkspace
+$ open Example/PlaybookExample.xcodeproj
 ```
 
 ### Lint & Format & Project Generation


### PR DESCRIPTION
## Checklist

- [x] All tests are passed.  
- [ ] Added tests or Playbook scenario.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description

Fix spelling of "Example" and change `xcworkspace` to `xcodeproj`

## Related Issue


## Motivation and Context


## Screenshots
