### PR TITLE
fix: Blank snapshot is generated if it exceeds the internal size limitation

### DIFF
--- a/Tests/ExtraScenarios.swift
+++ b/Tests/ExtraScenarios.swift
@@ -4,9 +4,15 @@ import SwiftUI
 
 enum ExtraScenarios: ScenarioProvider {
     static func addScenarios(into playbook: Playbook) {
+        playbook.addScenarios(of: "Extra") {
+            Scenario("Over internal size limitation 8192x8192", layout: .fixed(width: 10000, height: 10000)) {
+                Color.red.edgesIgnoringSafeArea(.all)
+            }
+        }
+
         playbook.addScenarios(of: "Normalizable\u{7FFFF}\u{1D} \n.:/") {
             Scenario("Normalizable\u{7FFFF}\u{1D} \n.:/", layout: .fixed(length: 300)) {
-                Color(.systemBlue).edgesIgnoringSafeArea(.all)
+                Color.blue.edgesIgnoringSafeArea(.all)
             }
         }
     }


### PR DESCRIPTION
## Checklist

- [x] All tests are passed.  
- [x] Added tests or Playbook scenario.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description

"Interestingly", `UIView.drawHierarchy` seems to have an internal hard-coded limit size of 8192x8192, and specifying a size beyond that resulting in an empty image is drawn.
It's reported in [Apple's developer forums](https://forums.developer.apple.com/forums/thread/121477) but there's no way properly address that issue.
So this PR adds a workaround that scales down the drawn image into a size that fits within the limitation once and then scales up to the expected size.
This may reduce the quality of the generated snapshots, but was not so critical when tested in the sample app.