### PR TITLE
Remove scenario title's line limit

### DIFF
--- a/Sources/PlaybookUI/Internal/Views/GalleryThumbnail.swift
+++ b/Sources/PlaybookUI/Internal/Views/GalleryThumbnail.swift
@@ -71,7 +71,7 @@ private struct NameLabel: View {
                 content: data.scenario.title.rawValue,
                 range: data.highlightRange
             )
-            .textStyle(font: .caption, lineLimit: 3)
+            .textStyle(font: .caption)
             .padding(.top, 4)
             .padding([.bottom, .horizontal], 8)
             .frame(maxWidth: .infinity)

--- a/Sources/PlaybookUI/Internal/Views/GalleryThumbnail.swift
+++ b/Sources/PlaybookUI/Internal/Views/GalleryThumbnail.swift
@@ -72,6 +72,7 @@ private struct NameLabel: View {
                 range: data.highlightRange
             )
             .textStyle(font: .caption)
+            .minimumScaleFactor(0.1)
             .padding(.top, 4)
             .padding([.bottom, .horizontal], 8)
             .frame(maxWidth: .infinity)

--- a/Tests/GalleryScenarios.swift
+++ b/Tests/GalleryScenarios.swift
@@ -33,6 +33,15 @@ enum GalleryScenarios: ScenarioProvider {
             Scenario("Detail", layout: .fill) { context in
                 GalleryDetail(data: .stub())
             }
+
+            Scenario("Thumbnail with long title", layout: .compressed) { context in
+                GalleryThumbnail(
+                    data: .stub(
+                        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+                    )
+                )
+                .environmentObject(ImageLoader())
+            }
         }
     }
 }

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -26,10 +26,10 @@ extension SelectData {
 }
 
 extension SearchedData {
-    static func stub(_ index: Int) -> Self {
+    static func stub(_ title: ScenarioTitle) -> Self {
         SearchedData(
             category: "Category",
-            scenario: .stub("Scenario \(index)"),
+            scenario: .stub(title),
             highlightRange: nil
         )
     }
@@ -37,7 +37,7 @@ extension SearchedData {
 
 extension SearchedCategoryData {
     static func stub(
-        scenarios: [SearchedData] = (0..<3).map { .stub($0) }
+        scenarios: [SearchedData] = (0..<3).map { .stub("Scenario \($0)") }
     ) -> Self {
         SearchedCategoryData(
             category: "Category",


### PR DESCRIPTION
## Checklist

- [x] All tests are passed.  
- [x] Added tests or Playbook scenario.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [ ] Searched existing pull requests for ensure not duplicated.  

## Description

If the title of the scenario is very long and it is cut in the middle, it will not be possible to distinguish between the scenarios, so this PR changes it to display the full title without removing the line limit.